### PR TITLE
refactored useFetchKeyData

### DIFF
--- a/client/hooks/useFetchKeyData.ts
+++ b/client/hooks/useFetchKeyData.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { fetchKeyData } from '../util/redux/keyDataReducer'
 import { RootState } from '../util/store'
-import type { KeyData, KeyDataMetadata, KeyDataProgramme, SingleKeyData, StudyProgramme } from '../lib/types'
+import type { SingleKeyData } from '../lib/types'
 
 export const useFetchSingleKeyData = (programmeId: string, lang: string): SingleKeyData => {
   const keyData = useFetchKeyData(lang)
@@ -22,84 +22,16 @@ export const useFetchSingleKeyData = (programmeId: string, lang: string): Single
 const useFetchKeyData = (lang: string) => {
   const dispatch = useDispatch()
   const keyData = useSelector((state: RootState) => state.keyData.data)
-  const programmeData = useSelector((state: RootState) => state.studyProgrammes.data)
 
   useEffect(() => {
-    dispatch(fetchKeyData())
+    dispatch(fetchKeyData(lang))
   }, [dispatch])
 
-  if (!keyData || !programmeData) {
+  if (!keyData) {
     return null
   }
 
-  const { Kandiohjelmat, Maisteriohjelmat, metadata } = keyData[0].data
-
-  const programmes = programmeData.map((programme: any) => {
-    const obj: StudyProgramme = {
-      key: programme.key,
-      name: programme.name[lang],
-      level: programme.level,
-      companionFaculties: programme.companionFaculties,
-      international: programme.international,
-    }
-    return obj
-  }) as StudyProgramme[]
-
-  const kandiohjelmat = Kandiohjelmat.map((kandiohjelma: any) => {
-    const matchedProgramme = programmes.find(
-      programme => programme.key === kandiohjelma['Koulutusohjelman koodi'].trim(),
-    )
-
-    const obj: KeyDataProgramme = {
-      koulutusohjelmakoodi: kandiohjelma['Koulutusohjelman koodi'],
-      koulutusohjelma: matchedProgramme ? matchedProgramme.name : kandiohjelma['Koulutusohjelman nimi'],
-      values: kandiohjelma,
-      vetovoimaisuus: kandiohjelma['Vetovoimaisuus'],
-      lapivirtaus: kandiohjelma['Läpivirtaus ja valmistuminen'],
-      opiskelijapalaute: kandiohjelma['Opiskelijapalaute ja työllistyminen'],
-      resurssit: kandiohjelma['Resurssit'],
-      year: kandiohjelma['Vuosi'],
-      international: matchedProgramme ? matchedProgramme.international : undefined,
-      level: matchedProgramme ? matchedProgramme.level : undefined,
-    }
-    return obj
-  }) as KeyDataProgramme[]
-
-  const maisteriohjelmat = Maisteriohjelmat.map((maisteriohjelma: any) => {
-    const matchedProgramme = programmes.find(
-      programme => programme.key === maisteriohjelma['Koulutusohjelman koodi'].trim(),
-    )
-    const obj: KeyDataProgramme = {
-      koulutusohjelmakoodi: maisteriohjelma['Koulutusohjelman koodi'],
-      koulutusohjelma: matchedProgramme ? matchedProgramme.name : maisteriohjelma['Koulutusohjelman nimi'],
-      values: maisteriohjelma,
-      vetovoimaisuus: maisteriohjelma['Vetovoimaisuus'],
-      lapivirtaus: maisteriohjelma['Läpivirtaus ja valmistuminen'],
-      opiskelijapalaute: maisteriohjelma['Opiskelijapalaute ja työllistyminen'],
-      resurssit: maisteriohjelma['Resurssit'],
-      year: maisteriohjelma['Vuosi'],
-      international: matchedProgramme ? matchedProgramme.international : undefined,
-      level: matchedProgramme ? matchedProgramme.level : undefined,
-    }
-    return obj
-  }) as KeyDataProgramme[]
-
-  const meta = metadata.map((meta: any) => {
-    const obj: KeyDataMetadata = {
-      avainluku: meta['Avainluku'],
-      kriteerinArvo: meta['Kriteerin nimi_fi'],
-      kriteerinNimi: meta[`Kriteerin nimi_${lang}`],
-      maaritelma: meta['Määritelmä'],
-      ohjelmanTaso: meta['Ohjelman taso'],
-      kynnysarvot: meta['Kynnysarvot'],
-      yksikko: meta['Yksikkö'],
-      liikennevalo: meta['Liikennevalo'], // boolean-kenttä sille näytetäänkö liikennevalo vai pelkkä luku
-      mittarinRajat: meta['Mittarin rajat'], 
-    }
-    return obj
-  }) as KeyDataMetadata[]
-
-  return { data: { kandiohjelmat, maisteriohjelmat, metadata: meta } } as KeyData
+  return keyData
 }
 
 export default useFetchKeyData

--- a/client/util/redux/keyDataReducer.ts
+++ b/client/util/redux/keyDataReducer.ts
@@ -13,8 +13,8 @@ interface Action {
   response?: any;
 }
 
-export const fetchKeyData = () => {
-  const route = '/keyData'
+export const fetchKeyData = (lang: string) => {
+  const route = `/keyData/${lang}`
   const prefix = 'GET_KEY_DATA'
   return callBuilder(route, prefix)
 }

--- a/server/services/keyDataService.ts
+++ b/server/services/keyDataService.ts
@@ -1,0 +1,61 @@
+export const formatKeyData = (data: any, programmeData: any, lang: string) => {
+  const { Kandiohjelmat, Maisteriohjelmat, metadata } = data
+
+  const programmes = programmeData.map((programme: any) => ({
+    key: programme.key,
+    name: programme.name[lang],
+    level: programme.level,
+    companionFaculties: programme.companionFaculties,
+    international: programme.international,
+  }))
+
+  const kandiohjelmat = Kandiohjelmat.map((kandiohjelma: any) => {
+    const matchedProgramme = programmes.find(
+      (programme: any) => programme.key === kandiohjelma['Koulutusohjelman koodi'].trim()
+    )
+    return {
+      koulutusohjelmakoodi: kandiohjelma['Koulutusohjelman koodi'],
+      koulutusohjelma: matchedProgramme ? matchedProgramme.name : kandiohjelma['Koulutusohjelman nimi'],
+      values: kandiohjelma,
+      vetovoimaisuus: kandiohjelma['Vetovoimaisuus'],
+      lapivirtaus: kandiohjelma['Läpivirtaus ja valmistuminen'],
+      opiskelijapalaute: kandiohjelma['Opiskelijapalaute ja työllistyminen'],
+      resurssit: kandiohjelma['Resurssit'],
+      year: kandiohjelma['Vuosi'],
+      international: matchedProgramme?.international,
+      level: matchedProgramme?.level,
+    }
+  })
+
+  const maisteriohjelmat = Maisteriohjelmat.map((maisteriohjelma: any) => {
+    const matchedProgramme = programmes.find(
+      (programme: any) => programme.key === maisteriohjelma['Koulutusohjelman koodi'].trim()
+    )
+    return {
+      koulutusohjelmakoodi: maisteriohjelma['Koulutusohjelman koodi'],
+      koulutusohjelma: matchedProgramme ? matchedProgramme.name : maisteriohjelma['Koulutusohjelman nimi'],
+      values: maisteriohjelma,
+      vetovoimaisuus: maisteriohjelma['Vetovoimaisuus'],
+      lapivirtaus: maisteriohjelma['Läpivirtaus ja valmistuminen'],
+      opiskelijapalaute: maisteriohjelma['Opiskelijapalaute ja työllistyminen'],
+      resurssit: maisteriohjelma['Resurssit'],
+      year: maisteriohjelma['Vuosi'],
+      international: matchedProgramme?.international,
+      level: matchedProgramme?.level,
+    }
+  })
+
+  const meta = metadata.map((m: any) => ({
+    arviointialue: m['Arviointialue'],
+    avainluvunArvo: m['Avainluvun nimi_fi'],
+    avainluvunNimi: m[`Avainluvun nimi_${lang}`],
+    maaritelma: m['Määritelmä_fi'],
+    ohjelmanTaso: m['Ohjelman taso'],
+    kynnysarvot: m['Kynnysarvot'],
+    yksikko: m['Yksikkö'],
+    liikennevalo: m['Liikennevalo'],
+    mittarinRajat: m['Mittarin rajat'],
+  }))
+
+  return { kandiohjelmat, maisteriohjelmat, metadata: meta }
+}

--- a/server/util/routes.js
+++ b/server/util/routes.js
@@ -78,7 +78,7 @@ router.get('/cypress/createAnswers/:form', notInProduction, cypress.createAnswer
 router.get('/cypress/createFacultyAnswers/:form', notInProduction, cypress.createFacultyAnswers)
 router.get('/cypress/initKeydata', notInProduction, cypress.initKeyData)
 
-router.get('/keydata', keyData.getKeyData)
+router.get('/keydata/:lang', keyData.getKeyData)
 router.post('/keydata', checkAdmin, keyData.uploadKeyData)
 
 export default router


### PR DESCRIPTION
This pull request includes significant changes to the key data fetching and formatting process, both on the client and server sides. The most important changes involve refactoring the data fetching logic to be language-specific and moving the data formatting logic to a dedicated service.

### Client-side changes:
* [`client/hooks/useFetchKeyData.ts`](diffhunk://#diff-decf44f90c6734f75541ea07e26061e68b30da60bd1637cd23a4e3fc0b4fef44L5-R5): Simplified the `useFetchKeyData` hook by removing the study programme data fetching and directly returning the key data. The `fetchKeyData` function now accepts a language parameter and dispatches the action with the specified language. [[1]](diffhunk://#diff-decf44f90c6734f75541ea07e26061e68b30da60bd1637cd23a4e3fc0b4fef44L5-R5) [[2]](diffhunk://#diff-decf44f90c6734f75541ea07e26061e68b30da60bd1637cd23a4e3fc0b4fef44L25-R34)
* [`client/util/redux/keyDataReducer.ts`](diffhunk://#diff-6abf0c68c8696a124c25db5c6eed9327bbf29f2a90aba85e6c49ba7f6e675cf8L16-R17): Modified the `fetchKeyData` action to include the language parameter in the API route.

### Server-side changes:
* [`server/controllers/keyDataController.ts`](diffhunk://#diff-31f5e053c63f6dfa2d59f49ab9a5737d4a82a8c4fcd10db33bbe8142c9578d50R5-R25): Updated the `getKeyData` controller to fetch study programme data and format the key data using the new `formatKeyData` service function. The controller now also supports a language query parameter.
* [`server/services/keyDataService.ts`](diffhunk://#diff-63f96ac09b901621a8af91d795ad353bd3ccf03aa44b619c7af614b0b1028725R1-R61): Added a new `formatKeyData` function to handle the formatting of key data, including mapping study programmes and metadata based on the specified language.
* [`server/util/routes.js`](diffhunk://#diff-11a3ba406356bf41e369db65fc76ec384be81ae423e69a0f1d7ba4cf0a84a6baL81-R81): Updated the key data route to include a language parameter.